### PR TITLE
Compress the alpha data in the output PDF. Fixes #14.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.9 - UNRELEASED - 2017-07-05
+### Changed
+- Apply FlateDecode to alpha channel of image streams (PR #15 Jon Oster)
+
 ## 0.0.8 - 2015-07-07
 ### Fixed
 - Plug several large memory leaks

--- a/lib/prawn/gmagick.rb
+++ b/lib/prawn/gmagick.rb
@@ -42,6 +42,8 @@ class Gmagick < Prawn::Images::Image
               :Decode           => [0, 1]
       )
       smask_obj.stream << alpha_mask
+      smask_obj.stream.filters << { FlateDecode: nil }
+
       obj.data[:SMask] = smask_obj
     end
 


### PR DESCRIPTION
This is to close #14. The alpha stream wasn't being compressed at all, yielding massive file sizes. 