### PR TITLE
add msys2 dependency for rubyinstaller2 windows

### DIFF
--- a/prawn-gmagick.gemspec
+++ b/prawn-gmagick.gemspec
@@ -10,5 +10,6 @@ Gem::Specification.new do |s|
   s.add_dependency "prawn", ">= 0.15", "< 3.0"
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "minitest"
+  s.metadata['msys2_mingw_dependencies'] = 'graphicsmagick'
   s.files = Dir.glob("{ext,lib,test}/**/*") + %w[README.markdown Rakefile]
 end


### PR DESCRIPTION
Adding this to the spec file will automatically download the graphicsmagick files on windows